### PR TITLE
Fix: 앵커 태그 클릭시 페이지 리로드, 앵커 태그 클릭시 서버로 요청하지 않도록 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./src/pages"></script>
+    <script type="module" src="./src/pages/index.js"></script>
   </body>
 </html>

--- a/src/pages/header/Header.js
+++ b/src/pages/header/Header.js
@@ -11,13 +11,13 @@ export class Header {
       <header class="header">
         <div class="header__container">
           <h1 class="header__heading-title">
-            <a href="/">
+            <a href="/" data-link="">
               <img
                 class="header__intranet-logo"
                 src="/src/assets/images/favicon/android-chrome-192x192.png"
                 alt="Logo"
               />
-              <span>Admin Dashboard</span>
+              <span>>Admin Dashboard</span>
             </a>
           </h1>
           <nav class="header__gnb">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,12 +53,17 @@ function router(props = {}) {
 router();
 // Handle navigation
 window.addEventListener('click', (e) => {
-  if (e.target.matches('[data-link]')) {
+  if (e.target.closest('a').matches('[data-link]')) {
     e.preventDefault();
-    history.pushState('', '', e.target.href);
+    const anchorElem = e.target.closest('a');
+    history.pushState('', '', anchorElem.href);
     const props = { data: 'data' };
     router(props);
   }
+});
+
+window.addEventListener('load', () => {
+  console.log('page loaded');
 });
 
 // // Update router


### PR DESCRIPTION
- Fix: Header.js 부분에 앵커에 data-link 추가함
-index.js 에 라우트 함수가 a태그 안에 다른 태그가 들어 있어도 실행되게 바꿈
Github issue #54