### PR TITLE
feat: 관리자 및 사용자 아이디/비밀번호 비교 후 리다이렉트 라우팅 처리

### DIFF
--- a/server/data/11b2ac8a015c5afca5db507d6587a42b.js
+++ b/server/data/11b2ac8a015c5afca5db507d6587a42b.js
@@ -1,0 +1,6 @@
+const admin = {
+  adminId: 'S1111111',
+  adminPass: '1234!@#$',
+};
+
+export { admin };

--- a/server/data/users.json
+++ b/server/data/users.json
@@ -1,15 +1,29 @@
 {
-  "status": "OK",
-  "data": [
+  "users": [
     {
-      "id": 1,
-      "userId": "abcd",
-      "email": "abcd@company.com"
+      "userId": "H2417001",
+      "userName": "고낙연",
+      "userPass": "helloworld1234"
     },
     {
-      "id": 2,
-      "userId": "xyz",
-      "email": "xyz@company.com"
+      "userId": "H2417002",
+      "userName": "송병훈",
+      "userPass": "helloworld1234"
+    },
+    {
+      "userId": "H2417003",
+      "userName": "신혜진",
+      "userPass": "helloworld1234"
+    },
+    {
+      "userId": "H2417004",
+      "userName": "이동혁",
+      "userPass": "helloworld1234"
+    },
+    {
+      "userId": "H2417005",
+      "userName": "최미랑",
+      "userPass": "helloworld1234"
     }
   ]
 }


### PR DESCRIPTION
- 비밀번호 유효성 검사 규칙 2가지 중 하나만 맞아도 통과
- 관리자로 로그인 체크하고, 관리자 아이디 및 비밀번호 입력 후 로그인 시 직원목록 페이지로 리다이렉트 후 다시 로딩
- 사용자 아이디 및 비밀번호 입력 후 로그인 버튼 클릭 시 - 사용자 데이터 fetch 하여 가져온 후 로그인에 필요한 userId와 userPass를 다시 객체 배열 생성 - 로그인 성공 시 사용자 홈 대시보드로 리다이렉트 후 다시 로딩 

사용자 타입 별 계정 데이터는 슬랙(서브페이지)에 공지함

- Github issue #125
