### PR TITLE
fix: 각 페이지 타이틀 텍스트 변경

### DIFF
--- a/src/pages/employeeListTable/EmployeeListTable.js
+++ b/src/pages/employeeListTable/EmployeeListTable.js
@@ -268,7 +268,7 @@ export class EmployeeListTable {
 
   onClickTableRow() {
     const pathMappings = {
-      '/userinfo': { title: 'userinfo', ComponentClass: UserInfo },
+      '/userinfo': { title: 'CORENET - 인트라넷 솔루션', ComponentClass: UserInfo },
     };
     const routeView = document.querySelector('route-view');
     const href = '/userinfo';

--- a/src/pages/header/Header.js
+++ b/src/pages/header/Header.js
@@ -13,7 +13,7 @@ export class Header {
 
   render() {
     // 대시보드 제목 및 링크 재설정
-    const dashboardTitle = this.isAdmin ? 'Admin Dashboard' : 'corenet';
+    const dashboardTitle = this.isAdmin ? 'Corenet Admin' : 'corenet';
     const dashboardLink = this.isAdmin ? '/employee-list' : '/';
 
     return /* HTML */ `

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,20 +48,20 @@ if (!sessionStorage.id) {
 
   const adminRoutes = {
     '/adminHome': {
-      title: 'Home',
+      title: 'CORENET Admin - Home',
       Component: Home,
     },
 
     '/': {
-      title: 'Employee List',
+      title: 'CORENET Admin - 직원관리',
       Component: EmployeeListTable,
     },
     '/userinfo': {
-      title: 'userinfo',
+      title: 'CORENET Admin - 인트라넷 솔루션',
       Component: UserInfo,
     },
     '/galleryManagement': {
-      title: 'GalleryManagement',
+      title: 'CORENET Admin - 갤러리 관리',
       Component: AdminGallery,
     },
     '/logout': {
@@ -73,19 +73,19 @@ if (!sessionStorage.id) {
   const userRoutes = {
     // 직원 페이지
     '/': {
-      title: 'Home',
+      title: 'CORENET - Home',
       Component: Home,
     },
     '/gallery': {
-      title: 'Gallery',
+      title: 'CORENET - 갤러리',
       Component: EmployeeGallery,
     },
     '/leave-application-list': {
-      title: 'leaveApplicationList',
+      title: 'CORENET - 근태신청',
       Component: LeaveApplicationList,
     },
     '/mypage': {
-      title: 'mypage',
+      title: 'CORENET - 마이페이지',
       Component: Mypage,
     },
   };

--- a/src/pages/mypage/Mypage.js
+++ b/src/pages/mypage/Mypage.js
@@ -80,7 +80,7 @@ export default class Mypage {
     userInfoButton.addEventListener('click', (e) => {
       e.preventDefault();
       const pathMappings = {
-        '/userinfo': { title: 'userinfo', ComponentClass: UserInfo },
+        '/userinfo': { title: 'CORENET - 인트라넷 솔루션', ComponentClass: UserInfo },
       };
       const routeView = document.querySelector('route-view');
       const route = new Route({ pathMappings, routeView });


### PR DESCRIPTION
각 페이지 방문 시, 페이지별 맞는 타이틀 설정을 위해 텍스트를 변경
특히 /userinfo 경로로 이동 시 공통 타이틀 사용하여, 사용자 경험 향상