### PR TITLE
Fix: server/index.js를 수정함.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,24 +6,13 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import { indb, initializeDatabase } from './initalizeData.js';
 import date from 'date-and-time';
-import cors from 'cors';
 
 const app = express();
 const PORT = process.env.PORT || 8080;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-app.use(
-  express.static(path.join(__dirname, '../dist'), {
-    setHeaders: (res, filePath) => {
-      if (path.extname(filePath) === '.css') {
-        res.setHeader('Content-Type', 'text/css');
-      } else if (path.extname(filePath) === '.js') {
-        res.setHeader('Content-Type', 'application/javascript');
-      }
-    },
-  }),
-);
+app.use(express.static(path.join(__dirname, '../dist')));
 
 // app.use(express.urlencoded({ extended: true }));
 app.use(morgan('dev'));
@@ -38,20 +27,7 @@ app.use(
           return context.parsedUrl.pathname;
         },
       },
-      {
-        from: /^\/dist\/.*$/,
-        to: function (context) {
-          return context.parsedUrl.pathname;
-        },
-      },
     ],
-  }),
-);
-
-app.use(
-  cors({
-    origin: 'http://localhost:8080',
-    credentials: true,
   }),
 );
 


### PR DESCRIPTION

## 📝작업 내용

- cors 부분을 삭제함.
- express.static이 content-type를 자동적을 지정하기 때문에 아래 부분을 삭제함.

## 💬리뷰 요구사항

- Q1. 일단은 이 history-fall-back로 서버에 지정되지 않은 라우트 주소들을 전부다 /index.html 로 요청을 rewrite시키도록 했는데 이렇게 한 이유는 저희는 src/index.js 에 있는 프론트엔드 라우터가 라우팅을 처리하기 때문에 이렇게 만들었습니다. 이렇게 하는것이 좋은 것인지는 모르겠네요.

- Q2. 가끔씩 content-type이 잘못 되었다는 에러가 배포 사이트를 접속했을 때 떠서 이부분을 추가했었습니다. 지금은 문제가 없기에 삭제를 했어요. 이런식으로 content-type를 명시하는것이 맞는지 궁금합니다. 

