### PR TITLE
design: 로딩 컴포넌트 디자인 수정

### DIFF
--- a/src/components/loading/Loading.css
+++ b/src/components/loading/Loading.css
@@ -1,3 +1,6 @@
+body {
+  max-width: none;
+}
 .loading-container {
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
body영역 max-width를 none으로 줘서 가로세로 모두 100% 먹도록 함