### PR TITLE
feat: 관리자페이지 EmployeeListTable(직원목록) 로딩 전에 Loading.js 컴포넌트 붙이기

### DIFF
--- a/src/pages/employeeListTable/EmployeeListTable.js
+++ b/src/pages/employeeListTable/EmployeeListTable.js
@@ -5,12 +5,15 @@ import Modal from '../../components/modal/ModalInofo.js';
 import { Route } from '../router/route.js';
 import UserInfo from '../userinfo/UserInfo.js';
 import { EmployeeListFetch } from './EmployeeListFetch.js';
+import Loading from '../../components/loading/Loading.js';
 
 export class EmployeeListTable {
   constructor(cotainer, props) {
     this.container = cotainer;
     this.props = props;
     this.employeeListFetch = new EmployeeListFetch();
+    this.loading = new Loading(this.container, {});
+    this.loading.render();
   }
 
   render() {
@@ -61,6 +64,7 @@ export class EmployeeListTable {
             <tbody class="employee-list__rows"></tbody>
           </table>
         </div>
+        <div class="page-nation-container"></div>
         <page-nation></page-nation>
         <div class="ex-modal-container"></div>
       </section>
@@ -70,9 +74,14 @@ export class EmployeeListTable {
   }
 
   async updateEmployeeListRows() {
-    const employees = await this.fetchEmployees();
-    this.renderTableRows({ cid: '.employee-list__rows', employees });
-    // this.attachEventListeners();
+    try {
+      const employees = await this.fetchEmployees();
+      this.renderTableRows({ cid: '.employee-list__rows', employees });
+    } catch (error) {
+      console.error('Error fetching employee list:', error);
+    } finally {
+      this.loading.hide();
+    }
   }
 
   renderTableRows({ cid, employees }) {
@@ -85,6 +94,11 @@ export class EmployeeListTable {
     let currentPage = 1;
 
     const pageNation = document.querySelector('page-nation');
+    if (!pageNation) {
+      console.error('Error: page-nation element not found');
+      this.displayError('페이지 네이션 요소를 찾을 수 없습니다.');
+      return;
+    }
     pageNation.innerHTML = /* HTML */ `
       <div class="pagination">
         <a

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,6 +13,7 @@ import Mypage from './mypage/Mypage';
 
 import Login from './login/userLogin.js';
 import LeaveApplicationList from './LeaveApplicationList/LeaveApplicationList.js';
+import Loading from '../components/loading/Loading.js';
 
 const app = document.querySelector('#app');
 
@@ -122,6 +123,34 @@ if (!sessionStorage.id) {
 
   window.addEventListener('load', () => {
     console.log('page loaded');
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const appContainer = document.getElementById('app');
+    const loading = new Loading(appContainer, {});
+    loading.render();
+
+    try {
+      // 데이터 로드 및 페이지 초기화
+      const initializeApp = async () => {
+        try {
+          // EmployeeListTable 초기화
+          const employeeListTable = new EmployeeListTable(appContainer, {});
+          // EmployeeListTable의 updateEmployeeListRows 메서드가 데이터를 로드합니다.
+          await employeeListTable.updateEmployeeListRows();
+          loading.hide();
+        } catch (error) {
+          console.error('Error initializing app:', error);
+          loading.hide();
+        }
+      };
+
+      // Promise 사용하여 초기화
+      initializeApp();
+    } catch (error) {
+      console.error('Error initializing app:', error);
+      loading.hide();
+    }
   });
 
   // // Update router


### PR DESCRIPTION
## 📝작업 내용

- 라우팅함수가 있는 index.js에 도큐먼트가 DOMContentLoaded되면, EmployeeListTable와 Loading컴포넌트 렌더링 하는 코드
- EmployeeListTable에서 Loading컴포넌트를 불러와 constructor에서 실행해주고, updateEmployeeListRows 함수 실행되면 Loading 컴포넌트 사라지게 하는 코드

## #️⃣연관된 이슈
어떠한 에러가 있었는지 이미지로 남기겠습니다.
![스크린샷 2024-07-15 오후 6 47 48](https://github.com/user-attachments/assets/d0c12608-915e-4d8c-ada0-41889e7c4177)


## 💬리뷰 요구사항
> 제가 작업한 순서(index.js -> )가 올바른지 궁금합니다. 
> 수정된 위의 코드 외에 어떠한 부분을 더 수정해야 에러처리를 할 수 있는지 너무 궁굼합니다
